### PR TITLE
Avoid running tests and vignettes on CRAN

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -28,6 +28,7 @@ jobs:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}
       TORCH_INSTALL: 1
+      TORCH_TEST: 1
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      TORCH_INSTALL: 1
+      TORCH_TEST: 1
     steps:
       - uses: actions/checkout@v2
 

--- a/R/dataset-utils.R
+++ b/R/dataset-utils.R
@@ -20,7 +20,7 @@ download_url <- function(url, destfile, checksum) {
 #' @return list: List of paths to extracted files even if not overwritten.
 #'
 #' @examples
-#'\dontrun{
+#'if(torch::torch_is_installed()) {
 #' url = 'http://www.quest.dcs.shef.ac.uk/wmt16_files_mmt/validation.tar.gz'
 #' from_path = './validation.tar.gz'
 #' to_path = './'

--- a/R/functional.R
+++ b/R/functional.R
@@ -367,7 +367,7 @@ functional_magphase <- function(
 #' @return `tensor`: Complex Specgrams Stretch with dimension of `(..., freq, ceiling(time/rate), complex=2)`
 #'
 #' @examples
-#' \dontrun{
+#' if(torch::torch_is_installed()) {
 #' library(torch)
 #' library(torchaudio)
 #'
@@ -1679,7 +1679,7 @@ functional_mask_along_axis <- function(
 #' @return `tensor`: Tensor of deltas of dimension (..., freq, time)
 #'
 #' @examples
-#' \dontrun{
+#' if(torch::torch_is_installed()) {
 #' library(torch)
 #' library(torchaudio)
 #' specgram = torch_randn(1, 40, 1000)

--- a/R/models-wavernn.R
+++ b/R/models-wavernn.R
@@ -13,7 +13,7 @@
 #' Tensor shape:  (n_batch, n_freq, n_time)
 #'
 #' @examples
-#' \dontrun{
+#' if(torch::torch_is_installed()) {
 #' resblock = model_resblock()
 #' input = torch::torch_rand(10, 128, 512)  # a random spectrogram
 #' output = resblock(input)  # shape: (10, 128, 512)
@@ -55,7 +55,7 @@ model_resblock <- torch::nn_module(
 #'
 #' @examples
 #'
-#' \dontrun{
+#' if(torch::torch_is_installed()) {
 #'  melresnet = model_melresnet()
 #'  input = torch::torch_rand(10, 128, 512)  # a random spectrogram
 #'  output = melresnet(input)  # shape: (10, 128, 508)
@@ -103,7 +103,7 @@ model_melresnet <- torch::nn_module(
 #' Tensor shape:  (..., n_freq * freq_scale, n_time * time_scale)
 #'
 #' @examples
-#' \dontrun{
+#' if(torch::torch_is_installed()) {
 #'  stretch2d = model_stretch2d(time_scale=10, freq_scale=5)
 #'
 #'  input = torch::torch_rand(10, 100, 512)  # a random spectrogram
@@ -147,7 +147,7 @@ model_stretch2d <- torch::nn_module(
 #'  where total_scale is the product of all elements in upsample_scales.
 #'
 #' @examples
-#' \dontrun{
+#' if(torch::torch_is_installed()) {
 #'  upsamplenetwork = model_upsample_network(upsample_scales=c(4, 4, 16))
 #'  input = torch::torch_rand (10, 128, 10)  # a random spectrogram
 #'  output = upsamplenetwork (input)  # shape: (10, 1536, 128), (10, 1536, 128)
@@ -232,7 +232,7 @@ model_upsample_network <- torch::nn_module(
 #' Tensor shape:  (n_batch, 1, (n_time - kernel_size + 1) * hop_length, n_classes)
 #'
 #' @examples
-#' \dontrun{
+#' if(torch::torch_is_installed()) {
 #' wavernn <- model_wavernn(upsample_scales=c(2,2,3), n_classes=5, hop_length=12)
 #'
 #' waveform <- torch::torch_rand(3,1,(10 - 5 + 1)*12)

--- a/man/extract_archive.Rd
+++ b/man/extract_archive.Rd
@@ -20,7 +20,7 @@ list: List of paths to extracted files even if not overwritten.
 Extract Archive
 }
 \examples{
-\dontrun{
+if(torch::torch_is_installed()) {
 url = 'http://www.quest.dcs.shef.ac.uk/wmt16_files_mmt/validation.tar.gz'
 from_path = './validation.tar.gz'
 to_path = './'

--- a/man/functional_compute_deltas.Rd
+++ b/man/functional_compute_deltas.Rd
@@ -27,7 +27,7 @@ where \code{d_t} is the deltas at time \code{t}, \code{c_t} is the spectrogram c
 \code{N} is \code{ (win_length-1) \%/\% 2}.
 }
 \examples{
-\dontrun{
+if(torch::torch_is_installed()) {
 library(torch)
 library(torchaudio)
 specgram = torch_randn(1, 40, 1000)

--- a/man/functional_phase_vocoder.Rd
+++ b/man/functional_phase_vocoder.Rd
@@ -20,7 +20,7 @@ functional_phase_vocoder(complex_specgrams, rate, phase_advance)
 Given a STFT tensor, speed up in time without modifying pitch by a factor of \code{rate}.
 }
 \examples{
-\dontrun{
+if(torch::torch_is_installed()) {
 library(torch)
 library(torchaudio)
 

--- a/man/model_melresnet.Rd
+++ b/man/model_melresnet.Rd
@@ -36,7 +36,7 @@ specgram  (Tensor): the input sequence to the MelResNet layer (n_batch, n_freq, 
 }
 \examples{
 
-\dontrun{
+if(torch::torch_is_installed()) {
  melresnet = model_melresnet()
  input = torch::torch_rand(10, 128, 512)  # a random spectrogram
  output = melresnet(input)  # shape: (10, 128, 508)

--- a/man/model_resblock.Rd
+++ b/man/model_resblock.Rd
@@ -21,7 +21,7 @@ forward param:
 specgram  (Tensor): the input sequence to the ResBlock layer (n_batch, n_freq, n_time).
 }
 \examples{
-\dontrun{
+if(torch::torch_is_installed()) {
 resblock = model_resblock()
 input = torch::torch_rand(10, 128, 512)  # a random spectrogram
 output = resblock(input)  # shape: (10, 128, 512)

--- a/man/model_stretch2d.Rd
+++ b/man/model_stretch2d.Rd
@@ -23,7 +23,7 @@ forward param:
 specgram  (Tensor): the input sequence to the Stretch2d layer (..., n_freq, n_time).
 }
 \examples{
-\dontrun{
+if(torch::torch_is_installed()) {
  stretch2d = model_stretch2d(time_scale=10, freq_scale=5)
 
  input = torch::torch_rand(10, 100, 512)  # a random spectrogram

--- a/man/model_upsample_network.Rd
+++ b/man/model_upsample_network.Rd
@@ -40,7 +40,7 @@ forward param:
 specgram  (Tensor): the input sequence to the UpsampleNetwork layer (n_batch, n_freq, n_time)
 }
 \examples{
-\dontrun{
+if(torch::torch_is_installed()) {
  upsamplenetwork = model_upsample_network(upsample_scales=c(4, 4, 16))
  input = torch::torch_rand (10, 128, 10)  # a random spectrogram
  output = upsamplenetwork (input)  # shape: (10, 1536, 128), (10, 1536, 128)

--- a/man/model_wavernn.Rd
+++ b/man/model_wavernn.Rd
@@ -57,7 +57,7 @@ The input channels of waveform and spectrogram have to be 1. The product of
 \code{upsample_scales} must equal \code{hop_length}.
 }
 \examples{
-\dontrun{
+if(torch::torch_is_installed()) {
 wavernn <- model_wavernn(upsample_scales=c(2,2,3), n_classes=5, hop_length=12)
 
 waveform <- torch::torch_rand(3,1,(10 - 5 + 1)*12)

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -2,4 +2,5 @@
 library(testthat)
 library(torchaudio)
 
-test_check("torchaudio")
+if (Sys.getenv("TORCH_TEST", unset = 0) == 1)
+  test_check("torchaudio")

--- a/vignettes/audio_preprocessing_tutorial.Rmd
+++ b/vignettes/audio_preprocessing_tutorial.Rmd
@@ -10,7 +10,8 @@ vignette: >
 ```{r, include = FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
-  comment = "#>"
+  comment = "#>",
+  eval = identical(Sys.getenv("TORCH_TEST", unset = "0"), "1")
 )
 ```
 


### PR DESCRIPTION
You should avoid running tests and vignettes on CRAN. Since torch installs additional software, this won't be allowed in the CRAN machines.

Also sometimes, CRAN will say that you can't have `\dontrun` in all examples. You can use `if(torch_is_installed())` to run the examples conditionally.