### PR TITLE
torch_arange now includes the end value.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,3 +41,5 @@ Imports:
 VignetteBuilder: knitr
 LinkingTo: 
     Rcpp
+Remotes:
+    mlverse/torch

--- a/R/kaldi.R
+++ b/R/kaldi.R
@@ -61,7 +61,7 @@ kaldi__get_lr_indices_and_weights <- function(
   dtype
 ) {
   if(lowpass_cutoff >= min(orig_freq, new_freq) / 2) value_error("lowpass_cutoff >= min(orig_freq, new_freq) / 2")
-  output_t = torch::torch_arange(0., output_samples_in_unit, device=device, dtype=dtype) / new_freq
+  output_t = torch::torch_arange(0., output_samples_in_unit-1, device=device, dtype=dtype) / new_freq
   min_t = output_t - window_width
   max_t = output_t + window_width
 
@@ -71,7 +71,7 @@ kaldi__get_lr_indices_and_weights <- function(
 
   max_weight_width = num_indices$max()
   # create a group of weights of size (output_samples_in_unit, max_weight_width)
-  j = torch::torch_arange(0, as.numeric(max_weight_width$to(device = "cpu")), device=device, dtype=dtype)$unsqueeze(1)
+  j = torch::torch_arange(0, as.numeric(max_weight_width$to(device = "cpu"))-1, device=device, dtype=dtype)$unsqueeze(1)
   input_index = min_input_index$unsqueeze(2) + j
   delta_t = (input_index / orig_freq) - output_t$unsqueeze(2)
 

--- a/tests/testthat/test-functional.R
+++ b/tests/testthat/test-functional.R
@@ -79,7 +79,7 @@ test_that("functional_create_dct", {
 })
 
 test_that("functional_amplitude_to_db and functional_db_to_amplitude", {
-  x1 <- torch::torch_arange(0,3, dtype = torch::torch_float())
+  x1 <- torch::torch_arange(0,2, dtype = torch::torch_float())
 
   # amplitude_to_DB
   x2 <- functional_amplitude_to_db(x1, multiplier = 10, amin = 1, db_multiplier = 2, top_db = 1)
@@ -94,7 +94,7 @@ test_that("functional_amplitude_to_db and functional_db_to_amplitude", {
 
 
 test_that("functional_mu_law_encoding and functional_mu_law_decoding", {
-  x1 <- torch::torch_arange(0,3, dtype = torch::torch_float())
+  x1 <- torch::torch_arange(0,2, dtype = torch::torch_float())
   # functional_mu_law_encoding
   x2 <- functional_mu_law_encoding(x1, quantization_channels = 300)
   expect_tensor(x2)
@@ -318,7 +318,7 @@ test_that("gain", {
 })
 
 test_that("add_noise_shaping", {
-  add_noise_shaping <- functional_add_noise_shaping(torch::torch_arange(0,5), torch::torch_arange(0,5))
+  add_noise_shaping <- functional_add_noise_shaping(torch::torch_arange(0,4), torch::torch_arange(0,5))
   expect_tensor(add_noise_shaping)
   expect_tensor_shape(add_noise_shaping, 5)
 })
@@ -407,7 +407,7 @@ test_that("median_smoothing", {
 
 test_that("sliding_window_cmn", {
   sliding_window_cmn <- functional_sliding_window_cmn(
-    waveform = torch::torch_arange(0, 15)$reshape(c(3, 5)),
+    waveform = torch::torch_arange(0, 14)$reshape(c(3, 5)),
     cmn_window = 600,
     min_cmn_window = 100,
     center = TRUE,

--- a/tests/testthat/test-transforms.R
+++ b/tests/testthat/test-transforms.R
@@ -35,7 +35,7 @@ test_that("transform_mel_spectrogram", {
 })
 
 test_that("transform_amplitude_to_db", {
-  x1 <- torch::torch_arange(0,3, dtype = torch::torch_float())
+  x1 <- torch::torch_arange(0,2, dtype = torch::torch_float())
 
   # amplitude_to_db
   x2 <- transform_amplitude_to_db()(x1)
@@ -102,7 +102,7 @@ test_that("transform_vol", {
   expect_error(transform_vol(-1, 'power'), class = "value_error")
 
   vol = transform_vol(-1, "db")
-  x1 <- torch::torch_arange(0,3, dtype = torch::torch_float())
+  x1 <- torch::torch_arange(0,2, dtype = torch::torch_float())
   vol_x1 = vol(x1)
   expect_tensor(vol_x1)
 


### PR DESCRIPTION
The next version of torch will change the behavior of `torch_arange`, it will now include the last element, making it much more consistent with R's `seq`. This PR changes all occurrences of `torch_arange` to make it work with the soon to be released torch version.

See also https://github.com/mlverse/torch/pull/506