### PR TITLE
Call path.expand on user-supplied directory before passing to untar

### DIFF
--- a/R/dataset-utils.R
+++ b/R/dataset-utils.R
@@ -34,7 +34,7 @@ extract_archive <- function(from_path, to_path = NULL, overwrite = FALSE) {
   if(ext_file %in% "zip") {
     utils::unzip(zipfile = from_path, exdir = to_path, overwrite = overwrite)
   } else if(grepl("tar", from_path)) {
-    utils::untar(tarfile = from_path, exdir = to_path)
+    utils::untar(tarfile = from_path, exdir = path.expand(to_path))
   }
 }
 


### PR DESCRIPTION
Unfortunately, `utils::untar()` does not call `path.expand()` before passing an `exdir` to the OS `tar` executable, which can cause failure when using, e.g., `path <- ~/somedir` (for me, this causes a failure running the code from https://blogs.rstudio.com/ai/posts/2021-02-04-simple-audio-classification-with-torch/)

