### PR TITLE
Fix typo in normalize tensor function

### DIFF
--- a/vignettes/audio_preprocessing_tutorial.Rmd
+++ b/vignettes/audio_preprocessing_tutorial.Rmd
@@ -142,7 +142,7 @@ normalize it.
 ```{r}
 normalize <- function(tensor) {
  # Subtract the mean, and scale to the interval [-1,1]
- tensor_minusmean <- tensor - tensor.mean()
+ tensor_minusmean <- tensor - tensor$mean()
  return(tensor_minusmean/tensor_minusmean$abs()$max())
 }
 


### PR DESCRIPTION
@Athospd, I noticed a typo within the definition of the `normalize()` function [here](https://github.com/curso-r/torchaudio/blob/33f6e9060a7ab9f04afb86f75d2fcd236fd1bd0c/vignettes/audio_preprocessing_tutorial.Rmd#L145). Python's dot notation was used instead of R's `$` extract operator. 

The current version produces this error:
```r
normalize(waveform)
# Error in tensor.mean() : could not find function "tensor.mean"
```
Changing `tensor.mean()` to `tensor$mean()` resolves this issue. 